### PR TITLE
Fix srgb_to_cct luminance threshold

### DIFF
--- a/python/isetcam/srgb_to_cct.py
+++ b/python/isetcam/srgb_to_cct.py
@@ -64,7 +64,10 @@ def srgb_to_cct(rgb: np.ndarray, *, table: np.ndarray | None = None) -> tuple[fl
 
     Y = xw[:, 1]
     topY = np.percentile(Y, 98)
-    topXYZ = xw[Y > topY]
+    # Use >= to avoid an empty selection when all Y values are equal.
+    topXYZ = xw[Y >= topY]
+    if topXYZ.size == 0:
+        topXYZ = xw
     topxy = chromaticity(topXYZ).mean(axis=0)
 
     diffs = np.linalg.norm(xy_table - topxy, axis=1)

--- a/python/tests/test_srgb_to_cct.py
+++ b/python/tests/test_srgb_to_cct.py
@@ -36,3 +36,9 @@ def test_srgb_to_cct_reuse_table():
     est2, table2 = srgb_to_cct(srgb2, table=table)
     assert table2 is table
     assert np.isclose(est2, 5000, atol=500)
+
+
+def test_srgb_to_cct_constant_image():
+    srgb = np.full((5, 5, 3), 0.5)
+    est, _ = srgb_to_cct(srgb)
+    assert isinstance(est, float)


### PR DESCRIPTION
## Summary
- prevent empty selections in `srgb_to_cct`
- test constant image case

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68481c05999c8333b3390e51392d14e6