### PR TITLE
Add basic image utilities

### DIFF
--- a/python/isetcam/__init__.py
+++ b/python/isetcam/__init__.py
@@ -126,6 +126,13 @@ from .imgproc import (
     faulty_insert,
     faulty_list,
     faulty_pixel_correction,
+    image_rotate,
+    image_translate,
+    image_flip,
+    image_crop_border,
+    ie_lut_digital,
+    ie_lut_linear,
+    ie_lut_invert,
 )
 from .ie_spectra_sphere import ie_spectra_sphere
 from .metrics.ie_psnr import ie_psnr
@@ -308,6 +315,13 @@ __all__ = [
     'faulty_insert',
     'faulty_list',
     'faulty_pixel_correction',
+    'image_rotate',
+    'image_translate',
+    'image_flip',
+    'image_crop_border',
+    'ie_lut_digital',
+    'ie_lut_linear',
+    'ie_lut_invert',
     'halftone_dither',
     'halftone_error_diffusion',
     'ie_psnr',

--- a/python/isetcam/imgproc/__init__.py
+++ b/python/isetcam/imgproc/__init__.py
@@ -5,6 +5,13 @@ from .image_distort import image_distort
 from .ie_internal_to_display import ie_internal_to_display
 from .image_illuminant_correction import image_illuminant_correction
 from .image_esser_transform import image_esser_transform
+from .image_rotate import image_rotate
+from .image_translate import image_translate
+from .image_flip import image_flip
+from .image_crop_border import image_crop_border
+from .ie_lut_digital import ie_lut_digital
+from .ie_lut_linear import ie_lut_linear
+from .ie_lut_invert import ie_lut_invert
 from .demosaic import (
     ie_nearest_neighbor,
     ie_bilinear,
@@ -29,4 +36,11 @@ __all__ = [
     "faulty_pixel_correction",
     "image_illuminant_correction",
     "image_esser_transform",
+    "image_rotate",
+    "image_translate",
+    "image_flip",
+    "image_crop_border",
+    "ie_lut_digital",
+    "ie_lut_linear",
+    "ie_lut_invert",
 ]

--- a/python/isetcam/imgproc/ie_lut_digital.py
+++ b/python/isetcam/imgproc/ie_lut_digital.py
@@ -1,0 +1,51 @@
+# mypy: ignore-errors
+"""Convert DAC values to linear RGB intensities using a gamma table."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Union
+
+
+def ie_lut_digital(dac: np.ndarray, g_table: Union[np.ndarray, float] = 2.2) -> np.ndarray:
+    """Return linear RGB values computed from ``dac`` through ``g_table``.
+
+    Parameters
+    ----------
+    dac : np.ndarray
+        Digital values. Can be 2-D or 3-D. Values must be integers in the
+        range ``[0, n_levels-1]`` where ``n_levels`` is the length of
+        ``g_table``.
+    g_table : Union[np.ndarray, float], optional
+        Gamma table mapping DAC values to linear intensity. If scalar,
+        ``dac`` values are raised to this power. Defaults to ``2.2``.
+
+    Returns
+    -------
+    np.ndarray
+        Linear intensity values in ``float``.
+    """
+
+    dac = np.asarray(dac)
+    if np.isscalar(g_table):
+        return dac.astype(float) ** float(g_table)
+
+    lut = np.asarray(g_table, dtype=float)
+    if lut.ndim == 1:
+        lut = lut[:, np.newaxis]
+    n_levels = lut.shape[0]
+
+    if dac.max() >= n_levels:
+        raise ValueError("DAC value exceeds gamma table length")
+
+    if lut.shape[1] == 1 and dac.ndim == 3:
+        lut = np.tile(lut, (1, dac.shape[2]))
+
+    if dac.ndim == 2:
+        dac_idx = dac.astype(int)
+        return lut[dac_idx, 0]
+
+    rgb = np.empty_like(dac, dtype=float)
+    for c in range(dac.shape[2]):
+        rgb[..., c] = lut[dac[..., c].astype(int), c if c < lut.shape[1] else 0]
+    return rgb

--- a/python/isetcam/imgproc/ie_lut_invert.py
+++ b/python/isetcam/imgproc/ie_lut_invert.py
@@ -1,0 +1,37 @@
+# mypy: ignore-errors
+"""Compute inverse lookup table from linear RGB to DAC values."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def ie_lut_invert(in_lut: np.ndarray, n_steps: int = 2048) -> np.ndarray:
+    """Return inverse lookup table of ``in_lut``.
+
+    Parameters
+    ----------
+    in_lut : np.ndarray
+        Lookup table mapping DAC to linear intensity.
+    n_steps : int, optional
+        Number of samples in the returned table. Defaults to ``2048``.
+
+    Returns
+    -------
+    np.ndarray
+        Inverse lookup table of shape ``(n_steps, n_channels)``.
+    """
+
+    lut = np.asarray(in_lut, dtype=float)
+    if lut.ndim == 1:
+        lut = lut[:, np.newaxis]
+
+    n_in = lut.shape[0]
+    y = np.arange(1, n_in + 1)
+    i_y = np.linspace(0, (n_steps - 1) / n_steps, n_steps)
+    out = np.zeros((n_steps, lut.shape[1]), dtype=float)
+    for c in range(lut.shape[1]):
+        x, idx = np.unique(lut[:, c], return_index=True)
+        out[:, c] = np.interp(i_y, x, y[idx], left=0, right=n_in)
+    np.clip(out, 0, n_in, out=out)
+    return out

--- a/python/isetcam/imgproc/ie_lut_linear.py
+++ b/python/isetcam/imgproc/ie_lut_linear.py
@@ -1,0 +1,47 @@
+# mypy: ignore-errors
+"""Convert linear RGB values to DAC through an inverse gamma table."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Union
+
+
+def ie_lut_linear(rgb: np.ndarray, g_table: Union[np.ndarray, float] = 2.2) -> np.ndarray:
+    """Return DAC values for ``rgb`` using ``g_table``.
+
+    Parameters
+    ----------
+    rgb : np.ndarray
+        Linear intensity values in the range ``[0, 1]``.
+    g_table : Union[np.ndarray, float], optional
+        Inverse gamma table mapping linear intensity to DAC. If scalar,
+        ``rgb`` values are raised to ``1/g_table``. Defaults to ``2.2``.
+
+    Returns
+    -------
+    np.ndarray
+        Integer DAC values.
+    """
+
+    rgb = np.asarray(rgb)
+    if np.isscalar(g_table):
+        return rgb.astype(float) ** (1.0 / float(g_table))
+
+    lut = np.asarray(g_table, dtype=float)
+    if lut.ndim == 1:
+        lut = lut[:, np.newaxis]
+    n_levels = lut.shape[0]
+
+    rgb_idx = np.clip((rgb * n_levels).astype(int), 0, n_levels - 1)
+
+    if lut.shape[1] == 1 and rgb.ndim == 3:
+        lut = np.tile(lut, (1, rgb.shape[2]))
+
+    if rgb.ndim == 2:
+        return lut[rgb_idx, 0]
+
+    dac = np.empty_like(rgb_idx, dtype=float)
+    for c in range(rgb.shape[2]):
+        dac[..., c] = lut[rgb_idx[..., c], c if c < lut.shape[1] else 0]
+    return dac

--- a/python/isetcam/imgproc/image_crop_border.py
+++ b/python/isetcam/imgproc/image_crop_border.py
@@ -1,0 +1,40 @@
+# mypy: ignore-errors
+"""Crop black border from an image."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Union
+
+
+def image_crop_border(img: np.ndarray, threshold: float = 0.06) -> np.ndarray:
+    """Return ``img`` cropped to its non-dark region.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Image data array. Can be 2-D or 3-D.
+    threshold : float, optional
+        Normalized threshold used to detect the border. Defaults to ``0.06``.
+
+    Returns
+    -------
+    np.ndarray
+        Cropped image. If no non-dark region is found the original image is
+        returned.
+    """
+
+    if img.ndim == 3:
+        gray = 0.2989 * img[..., 0] + 0.5870 * img[..., 1] + 0.1140 * img[..., 2]
+    else:
+        gray = img.astype(float)
+
+    binary = gray > threshold
+    rows, cols = np.where(binary)
+    if rows.size == 0 or cols.size == 0:
+        return img
+    row1, row2 = rows.min(), rows.max()
+    col1, col2 = cols.min(), cols.max()
+    if row2 > row1 and col2 > col1:
+        return img[row1 : row2 + 1, col1 : col2 + 1, ...]
+    return img

--- a/python/isetcam/imgproc/image_flip.py
+++ b/python/isetcam/imgproc/image_flip.py
@@ -1,0 +1,33 @@
+# mypy: ignore-errors
+"""Flip an image array horizontally or vertically."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def image_flip(img: np.ndarray, flip_type: str) -> np.ndarray:
+    """Flip ``img``.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Image data array. Can be 2-D or 3-D.
+    flip_type : str
+        ``'updown'`` for vertical flip or ``'leftright'`` for horizontal flip.
+        The first character is sufficient.
+
+    Returns
+    -------
+    np.ndarray
+        Flipped image array.
+    """
+
+    if flip_type is None:
+        raise ValueError("flip_type required")
+    ft = flip_type.lower()
+    if ft.startswith("u"):
+        return np.flip(img, axis=0)
+    if ft.startswith("l"):
+        return np.flip(img, axis=1)
+    raise ValueError("flip_type must be 'updown' or 'leftright'")

--- a/python/isetcam/imgproc/image_rotate.py
+++ b/python/isetcam/imgproc/image_rotate.py
@@ -1,0 +1,49 @@
+# mypy: ignore-errors
+"""Rotate an image array."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.ndimage import rotate as nd_rotate
+from typing import Union
+
+
+def image_rotate(img: np.ndarray, rot_type: Union[str, float], fill: float = 0) -> np.ndarray:
+    """Rotate ``img``.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Image data array. Can be 2-D or 3-D.
+    rot_type : Union[str, float]
+        If ``'cw'`` or ``'clockwise'`` rotate 90 degrees clockwise.
+        If ``'ccw'`` or ``'counterclockwise'`` rotate 90 degrees
+        counter-clockwise. Otherwise interpreted as rotation angle in
+        degrees. Positive values rotate counter-clockwise.
+    fill : float, optional
+        Fill value used for regions introduced by rotation. Defaults to ``0``.
+
+    Returns
+    -------
+    np.ndarray
+        Rotated image array in floating point format.
+    """
+
+    if isinstance(rot_type, str):
+        rt = rot_type.lower()
+        if rt in {"cw", "clockwise"}:
+            return np.rot90(img, k=-1, axes=(0, 1))
+        if rt in {"ccw", "counterclockwise"}:
+            return np.rot90(img, k=1, axes=(0, 1))
+        raise ValueError("Unknown rotation type")
+
+    rotated = nd_rotate(
+        img,
+        float(rot_type),
+        axes=(1, 0),
+        reshape=True,
+        order=1,
+        mode="constant",
+        cval=float(fill),
+    )
+    return rotated

--- a/python/isetcam/imgproc/image_translate.py
+++ b/python/isetcam/imgproc/image_translate.py
@@ -1,0 +1,47 @@
+# mypy: ignore-errors
+"""Translate an image array."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def image_translate(img: np.ndarray, dx: int, dy: int, fill: float = 0) -> np.ndarray:
+    """Shift ``img`` by ``dx`` and ``dy`` pixels.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Image data array. Can be 2-D or 3-D.
+    dx, dy : int
+        Horizontal and vertical shift in pixels. Positive values shift the
+        image right and down respectively.
+    fill : float, optional
+        Fill value for areas exposed by the shift. Defaults to ``0``.
+
+    Returns
+    -------
+    np.ndarray
+        Shifted image array in same dtype as ``img``.
+    """
+
+    h, w = img.shape[:2]
+    shifted = np.full_like(img, fill)
+    if abs(dx) < w and abs(dy) < h:
+        if dx >= 0:
+            src_x = slice(0, w - dx)
+            dst_x = slice(dx, dx + (w - dx))
+        else:
+            src_x = slice(-dx, w)
+            dst_x = slice(0, w + dx)
+
+        if dy >= 0:
+            src_y = slice(0, h - dy)
+            dst_y = slice(dy, dy + (h - dy))
+        else:
+            src_y = slice(-dy, h)
+            dst_y = slice(0, h + dy)
+
+        shifted[dst_y, dst_x, ...] = img[src_y, src_x, ...]
+
+    return shifted

--- a/python/tests/test_image_ops.py
+++ b/python/tests/test_image_ops.py
@@ -1,0 +1,60 @@
+import numpy as np
+from scipy.ndimage import rotate as nd_rotate
+
+from isetcam import (
+    image_flip,
+    image_rotate,
+    image_translate,
+    image_crop_border,
+    ie_lut_digital,
+    ie_lut_linear,
+    ie_lut_invert,
+)
+
+
+def test_image_flip():
+    img = np.arange(6).reshape(2, 3)
+    assert np.array_equal(image_flip(img, "updown"), np.flip(img, axis=0))
+    assert np.array_equal(image_flip(img, "leftRight"), np.flip(img, axis=1))
+
+
+def test_image_rotate():
+    img = np.arange(6).reshape(2, 3)
+    out = image_rotate(img, "cw")
+    assert np.array_equal(out, np.rot90(img, -1))
+    angle = 30
+    out = image_rotate(img, angle, fill=-1)
+    expected = nd_rotate(img, angle, axes=(1, 0), reshape=True, order=1, mode="constant", cval=-1)
+    assert np.allclose(out, expected)
+
+
+def test_image_translate():
+    img = np.arange(9).reshape(3, 3)
+    out = image_translate(img, 1, 1, fill=-1)
+    expected = np.full_like(img, -1)
+    expected[1:, 1:] = img[:-1, :-1]
+    assert np.array_equal(out, expected)
+
+
+def test_ie_lut_scalar():
+    img = np.array([[0, 1]], dtype=float)
+    digital = ie_lut_linear(img, 2)
+    assert np.allclose(digital, img ** 0.5)
+    rgb = ie_lut_digital(digital, 2)
+    assert np.allclose(rgb, img)
+
+
+def test_ie_lut_invert():
+    table = np.linspace(0, 1, 4)[:, None]
+    inv = ie_lut_invert(table, 4)
+    assert inv.shape == (4, 1)
+    assert np.allclose(inv[:, 0], np.linspace(1, 4, 4))
+
+
+def test_image_crop_border():
+    img = np.zeros((5, 5))
+    img[1:4, 1:4] = 1
+    cropped = image_crop_border(img, threshold=0.1)
+    assert cropped.shape == (3, 3)
+    assert np.allclose(cropped, 1)
+


### PR DESCRIPTION
## Summary
- implement basic image cropping, flipping, translation, rotation
- add LUT helpers (digital/linear/invert)
- expose new functions through package init
- test new image operations

## Testing
- `pip install -e python` *(fails: Could not install due to missing network)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'isetcam')*

------
https://chatgpt.com/codex/tasks/task_e_684bc644c4d4833380e1c47238ac81d3